### PR TITLE
Add SNES input selection and improve controller routing

### DIFF
--- a/src/components/snes/controller.tsx
+++ b/src/components/snes/controller.tsx
@@ -101,10 +101,21 @@ export default function SnesController({ sessionId, playerId }: Props) {
     setStarted(true)
   }
 
+  const playerPrefix = useMemo(() => {
+    if (playerId === '1') return 'p1'
+    if (playerId === '2') return 'p2'
+    return null
+  }, [playerId])
+
+  const mapControl = (control: string) => {
+    if (control.startsWith('__')) return control
+    return playerPrefix ? `${playerPrefix}_${control}` : control
+  }
+
   function send(control: string, state: 'down' | 'up') {
-    const payload = { type: 'button', control, state }
+    const payload = { type: 'button', control: mapControl(control), state }
     console.log('[Controller] Sending:', payload, 'to:', pushUrl)
-    
+
     if (pushUrl) {
       fetch(pushUrl, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) })
         .then(res => {


### PR DESCRIPTION
## Summary
- add an initial landing step on the SNES page so players can choose keyboard play or generate phone controller QR codes
- keep navigation flexible with links back to the control-method picker and improve emulator event dispatching so remote inputs reliably reach the game
- update the mobile controller to emit player-scoped inputs for compatibility with the two-player keyboard mapping

## Testing
- npm run lint *(fails: next lint is deprecated and forwards unsupported options in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68da624c4df0832e876a9012ca1d08ec